### PR TITLE
Adding compilation instructions for Linux

### DIFF
--- a/VST/Makefile
+++ b/VST/Makefile
@@ -20,7 +20,9 @@ ifeq ($(ARCH), win)
 	TARGET := $(TARGET).dll
 endif
 ifeq ($(ARCH), lin)
-$(error The VST plugin is not available for Linux at this time. If you've built Linux VSTs before, you're welcome to contribute to the build system)
+	FLAGS += -D__cdecl=""
+	LDFLAGS += -lpthread -shared
+	TARGET := $(TARGET).so
 endif
 
 
@@ -55,6 +57,12 @@ ifeq ($(ARCH), win)
 	strip -s dist/$(TARGET)
 	cd dist && zip -5 -r VCV-Bridge-$(VERSION)-$(ARCH)-VST.zip $(TARGET)
 endif
+ifeq ($(ARCH), lin)
+	mkdir -p dist
+	cp $(TARGET) dist/
+	strip -s dist/$(TARGET)
+	cd dist && zip -5 -r VCV-Bridge-$(VERSION)-$(ARCH)-VST.zip $(TARGET)
+endif
 
 install: dist
 ifeq ($(ARCH), mac)
@@ -64,11 +72,19 @@ ifeq ($(ARCH), win)
 	mkdir -p /c/Program\ Files/Steinberg/VstPlugins
 	cp -R dist/$(TARGET) /c/Program\ Files/Steinberg/VstPlugins/
 endif
+ifeq ($(ARCH), lin)
+	mkdir -p ~/.vst/
+	cp -R dist/$(TARGET) ~/.vst
+endif
 
 uninstall:
 ifeq ($(ARCH), mac)
 	sudo rm -rfv /Library/Audio/Plug-Ins/VST/$(BUNDLE)
 endif
+ifeq ($(ARCH), lin)
+	rm -f /.vst/$(TARGET)
+endif
+
 
 run: install
 ifeq ($(ARCH), win)


### PR DESCRIPTION
Hello,

With the proposed modification the compilation is fine on Linux, minus some warning from gcc (cgg 5.4.0, tested with Ubuntu 16.04).

However the plugin might require some more work to be functional. Indeed, once loaded and activated in a host, the audio engine becomes slugish (running jack here). I tested with carla and Ardour (last versions from kxstudio repository), in both cases there are many drops and a synth in a separate track would get very noisy.

As for communicating with Rack, it is even worse when trying to send or receive an audio stream, so many drops that we almost cannot hear a thing. The notes event (e.g. with MIDI-4) hardly make it through, and the MIDI CC events (what I am really after in my case) are slightly better but still very laggy.

I don't know if the problems come from the plugin or from the current implementation of Rack -- tested with 0.6 release and with the latest git version. Oddly, when I activate the power meter with the later, and when a connexion is established with a plugin, the meter jumps toward 2000ms (even if I play around with the sampling rate of the engine).

Note that before that I managed to use the *windows* VST (grabbed from the 0.6 release), using linvst. The plugin is then much more functional, but the symptoms are still present. 

Tell me if/how I can help investigating the situation. I am very new to VCV Rack (and new to music creation in general), I just fell in love with some of the modules this WE and I'd like it very much to integrate it in my wokflow -- thanks for your great work BTW :)

Again, I'm mostly interested in the MIDI CC events, in order to control few parameters from the outside as well as save/load "presets" from the VST host (the plugin would be the easiest solution to achieve that). A reduced version in the meantime (e.g. without audio) would still represent a huge improvement for me, I would then rely on jack to route the audio (...the only tricky thing being that Rack does not seem to directly create its own jack port, but that is probably an issue to save for the Rack repo).

