### PR TITLE
Remove broken include

### DIFF
--- a/common/client.cpp
+++ b/common/client.cpp
@@ -1,4 +1,3 @@
-#include "util/common.hpp"
 #include "dsp/ringbuffer.hpp"
 #include "bridgeprotocol.hpp"
 


### PR DESCRIPTION
The "util/common.hpp" include prevented the build on Linux.
Simply removing the line in client.cpp fixed the problem.

The #include "dsp/ringbuffer.hpp"
can apparently be removed also without trouble

Tested on Ubuntu Studio 19.04